### PR TITLE
Corrected spelling and grammar mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ orangutan is a lightweight and SUPER simple rust web server library inspired by 
 
 ## Installation (cargo)
 
-Unfortunately you must add more than one crate to use orangutan because of the macro. This will be fixed in the future but for now I am sorry for the inconvenience.
+Unfortunately, you must add more than one crate to use orangutan because of the macro. This will be fixed in the future but for now I am sorry for the inconvenience.
 
 In the Cargo.toml add:
 
@@ -23,24 +23,24 @@ This is what a minimal orangutan application looks like:
 use orangutan::*;
 
 // Use the 'route'-macro to define the path, method(s) and a handler
-#[route(path="/hello", method="[POST, GET]")] 
+#[route(path="/hello", method="[POST, GET]")]
 fn hello_handler(request: &Request) -> Response {
 
     // Handler has to return a Response           
     let mut res = Response::new();
 
-    // Use the 'insert'-method to insert text/json into the Response     
-    res.insert("Hello!"); 
+    // Use the 'insert'-method to insert text/JSON into the Response     
+    res.insert("Hello!");
 
-    res 
+    res
 
 }
 
-fn main() {    
-    // Create an new Orangutan
-    let mut app = Orangutan::new("127.0.0.1:8080"); 
+fn main() {
+    // Create a new Orangutan
+    let mut app = Orangutan::new("127.0.0.1:8080");
 
-    // This automatically makes the Orangutan run with the handler and routes assigned to it.      
+    // This automatically makes the Orangutan run with the handler and routes assigned to it.
     app.run();
 
     // Now you have a web server listening on http://127.0.0.1:8080/hello 
@@ -70,15 +70,15 @@ use orangutan::*;
 #[route(path="/<str:username>", method="[GET, POST]")]
 fn username_handler(request: &Request) -> Response {
     // This handler is responsible for every request in the path: "/something"
-    // The name of the variable (username) is defined after the variables type 
+    // The name of the variable (username) is defined after the variable's type 
 
-    let mut res = Response::new();          
+    let mut res = Response::new();
 
     // We use the get_var() method to get the value of the variable in the request
     let username: String = request.get_var("username");
 
     // We can do whatever we want with the username
-    res.insert(format!("Hello, {}", username));    
+    res.insert(format!("Hello, {}", username));
 
     res
 
@@ -90,25 +90,26 @@ fn number_handler(request: &Request) -> Response {
     // This handler is responsible for every request in the path: "/something"
     // Same as username handler except the value of the variable is i32.  
 
-    let mut res = Response::new();          
+    let mut res = Response::new();
 
     let number: i32 = request.get_var("number");
 
-    res.insert(format!("{} * 2 = {}", number, number*2));    
+    res.insert(format!("{} * 2 = {}", number, number*2));
 
     res
 
 }
 
-fn main() {    
-    let mut app = Orangutan::new("127.0.0.1:8080");   
+fn main() {
+    let mut app = Orangutan::new("127.0.0.1:8080");
 
-    app.run();     
+    app.run();
 }
 ```
-## Json Requests
 
-In this example I will show you how to handle Requests that contain Json data
+## JSON Requests
+
+In this example, I will show you how to handle Requests that contain JSON data
 
 ```rust
 use orangutan::*;
@@ -116,39 +117,39 @@ use orangutan::*;
 #[route(path="/order", method="[GET, POST]")]
 fn order_handler(request: &Request) -> Response {
 
-    let mut res = Response::new();          
+    let mut res = Response::new();
 
-    // .json() returns an Option<Value>, where Some represents the json Value and None means that there is no json Value in the request
+    // .json() returns an Option<Value>, where Some represents the JSON Value and None means that there is no JSON Value in the request
     let order_data = request.json();
 
-    // Let us use match to see if the request contains Json Value or not
+    // Let us use match to see if the request contains JSON Value or not
     match order_data {
-        // Great. The reqeust contains Json Value
-        Some(data) => { 
+        // Great. The request contains JSON Value
+        Some(data) => {
             let order: Option<&Value> = data.get("order");
 
             println!("The order: {}", order.unwrap());
         }
         None => { println!("This means that the request does not contain any json data");}
-    }    
+    }
 
     res
 }
 
-fn main() {    
-    let mut a = Orangutan::new("127.0.0.1:8080");   
+fn main() {
+    let mut a = Orangutan::new("127.0.0.1:8080");
 
-    a.run();     
+    a.run();
 }
 ```
 
-A great way to test how this works is by utilizing tools like curl on Linux. Lets see how our program behaves.
+A great way to test how this works is by utilizing tools like curl on Linux. Let's see how our program behaves.
 
 ```bash
 curl -i -H "Content-Type: application/json" -X POST -d '{"order":"Computer", "OS": "Linux"}' http://127.0.0.1:8080/order
 ```
 
-Lets see how out program responses to this:
+Let's see how our program responds to this:
 
 The output of the program:
 
@@ -156,21 +157,21 @@ The output of the program:
 The order: "Computer"
 ```
 
-What if the request does not contain any json Values?
+What if the request does not contain any JSON values?
 
-Lets use this command:
+Let's use this command:
 
 ```bash
-curl -X GET -H "Content-Type: text/plain" -d "This is not Json Value" http://127.0.0.1:8080/order
+curl -X GET -H "Content-Type: text/plain" -d "This is not JSON Value" http://127.0.0.1:8080/order
 ```
 
 And again the output is this:
 
 ```bash
-This means that the request does not contain any json data
+This means that the request does not contain any JSON data
 ```
 
-If the request does contain Json Value but the Value does not contain the "order" field then our program will 'panic' BUT that does not crash the server thankfully.
+If the request does contain JSON Value but the Value does not contain the "order" field then our program will 'panic' BUT that does not crash the server thankfully.
 
 ## Aborting requests
 
@@ -178,14 +179,14 @@ Sometimes you need to simply return an error. This is how:
 
 ```rust
 #[route(path="/only_vip", method="[GET, POST]")]
-fn user_satus_handler(request: &Request) -> Response {
+fn user_status_handler(request: &Request) -> Response {
 
-    let mut res = Response::new();          
+    let mut res = Response::new();
 
     let user_data = request.json();
-    
-    match user_data {        
-        Some(data) => { 
+
+    match user_data {
+        Some(data) => {
             let user_status: Option<&Value> = data.get("user_status");
 
             if user_status.unwrap() != "VIP" {
@@ -193,11 +194,11 @@ fn user_satus_handler(request: &Request) -> Response {
                 res.abort(request, 403);
             } else {
                 res.insert("Welcome to the club!");
-            }            
+            }
         }
 
         None => { res.abort(request, 404) }
-    }    
+    }
 
     res
 }
@@ -211,7 +212,7 @@ There are many ways of making Responses. Here are some different ways of doing t
 #[route(path="/", method="[GET, POST]")]
 fn handler(request: &Request) -> Response {
 
-    let mut res = Response::new();          
+    let mut res = Response::new();
 
     // Here are 3 methods for doing the same thing
     res.set_content_type(ContentType::TextHtml);
@@ -234,3 +235,4 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 ## License
 
 [MIT](https://choosealicense.com/licenses/mit/)
+```


### PR DESCRIPTION
Corrected many spelling and grammar mistakes, removed trailing whitespace, and changed "json" and/or "Json" to "JSON"